### PR TITLE
update drun application directory paths

### DIFF
--- a/worf/src/lib/desktop.rs
+++ b/worf/src/lib/desktop.rs
@@ -76,17 +76,21 @@ pub fn find_desktop_files() -> Vec<DesktopFile> {
 
     if let Some(home) = dirs::home_dir() {
         paths.push(home.join(".local/share/applications"));
+        paths.push(home.join(".local/share/flatpak/exports/share/applications"));
     }
 
     if let Ok(xdg_data_home) = env::var("XDG_DATA_HOME") {
-        paths.push(PathBuf::from(xdg_data_home).join(".applications"));
+        paths.push(PathBuf::from(xdg_data_home.clone()).join("applications"));
+        paths.push(PathBuf::from(xdg_data_home).join("flatpak/exports/share/applications"));
     }
 
     if let Ok(xdg_data_dirs) = env::var("XDG_DATA_DIRS") {
         for dir in xdg_data_dirs.split(':') {
-            paths.push(PathBuf::from(dir).join(".applications"));
+            paths.push(PathBuf::from(dir).join("applications"));
         }
     }
+    paths.sort();
+    paths.dedup();
 
     let p: Vec<_> = paths
         .into_par_iter()


### PR DESCRIPTION
I noticed in my usage of worf that `--show drun` was not finding per-user flatpak applications. This PR is just some very minor changes to the application search path setup, summarized below.

* fixed xdg-data-home and xdg-data-dirs application directory paths
  * these had been pointing to directories with a basename of `.applications` rather than `applications`
* added flatpak per-user application paths
* deduplicate application paths before searching
  * this brought my machine from finding 256 desktop files in a range of ~10-12ms to 135 desktop files in a range of ~7-9ms. This admittedly seemed like more of a concern with the debug builds which, were brought down from ~30-35ms to ~15-18ms.