### PR TITLE
Adding maintainer to worf/Cargo.toml and updated README.md to include…

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ You will find all worf binaries, including the examples, in `./target/release`.
 Copy the binaries you need into a path that is part of `$PATH`, for example `/usr/bin`.
 Installing via cargo (once available) will put the binaries in `$HOME/.cargo/bin`.
 
+On debian based systems, Cargo-deb can be used to build a deb package for installation purposes. Note, the deb package cannot be distributed at this time, it can only be used on the system that built worf. Within the root of the git repo, run the following:
+
+Install cargo-deb
+```bash
+cargo install cargo-deb
+```
+
+Create deb package and install
+
+```bash
+cargo deb -p worf-launcher
+sudo apt install ./target/debian/worf-launcher-xxxx.deb
+```
+
 
 ## Configuring Worf
 

--- a/worf/Cargo.toml
+++ b/worf/Cargo.toml
@@ -31,6 +31,9 @@ path = "src/main.rs"
 [features]
 default = []
 
+[package.metadata.deb]
+maintainer = "Alexander Mohr"
+
 [package.metadata.docs.rs]
 no-deps = true
 

--- a/worf/src/lib/gui.rs
+++ b/worf/src/lib/gui.rs
@@ -701,7 +701,7 @@ fn build_ui<T>(
 
     log::debug!("window show took {:?}", window_start.elapsed());
 
-    log::debug!("Building UI took {:?}", start.elapsed(),);
+    log::debug!("Building UI took {:?}", start.elapsed());
 }
 
 fn create_background(config: &Config) -> Option<ApplicationWindow> {

--- a/worf/src/lib/modes/math.rs
+++ b/worf/src/lib/modes/math.rs
@@ -318,10 +318,10 @@ fn eval_expr(tokens: &mut VecDeque<Token>) -> Result<Value, String> {
             return Err("Mismatched parentheses".to_owned());
         }
         let b = values.pop().ok_or_else(|| {
-            format!("Missing right operand in final evaluation (values: {values:?}, ops: {ops:?})",)
+            format!("Missing right operand in final evaluation (values: {values:?}, ops: {ops:?})")
         })?;
         let a = values.pop().ok_or_else(|| {
-            format!("Missing left operand in final evaluation (values: {values:?}, ops: {ops:?})",)
+            format!("Missing left operand in final evaluation (values: {values:?}, ops: {ops:?})")
         })?;
         values.push(apply_op(&a, &b, &op));
     }


### PR DESCRIPTION
Adding cargo-deb instructions along with a maintainer field (to avoid apt warning). This allows cargo to build deb packages for use in apt based distros.